### PR TITLE
Simplify PHP syntax

### DIFF
--- a/controllers/add_book.php
+++ b/controllers/add_book.php
@@ -1,15 +1,15 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+include 'models/book_model.php';
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] != 'admin') {
     header('Location: index.php?page=login');
     exit;
 }
 $message = '';
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $title = $_POST['title'] ?? '';
-    $author = $_POST['author'] ?? '';
-    $category = $_POST['category'] ?? '';
-    $isbn = $_POST['isbn'] ?? '';
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $title = isset($_POST['title']) ? $_POST['title'] : '';
+    $author = isset($_POST['author']) ? $_POST['author'] : '';
+    $category = isset($_POST['category']) ? $_POST['category'] : '';
+    $isbn = isset($_POST['isbn']) ? $_POST['isbn'] : '';
     if (add_book($title, $author, $category, $isbn)) {
         header('Location: index.php?page=dashboard');
         exit;
@@ -17,6 +17,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $message = 'Failed to add book';
     }
 }
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/add_book.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/add_book.php';
+include 'views/footer.php';

--- a/controllers/book.php
+++ b/controllers/book.php
@@ -1,7 +1,7 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
-require_once __DIR__ . '/../models/borrow_model.php';
-$id = $_GET['id'] ?? 0;
+include 'models/book_model.php';
+include 'models/borrow_model.php';
+$id = isset($_GET['id']) ? $_GET['id'] : 0;
 $book = get_book($id);
 $is_borrowed = false;
 $user_borrow_id = null;
@@ -14,6 +14,6 @@ if ($book) {
         }
     }
 }
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/book.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/book.php';
+include 'views/footer.php';

--- a/controllers/books.php
+++ b/controllers/books.php
@@ -1,8 +1,8 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
-$search = $_GET['search'] ?? '';
-$order = $_GET['order'] ?? 'title';
+include 'models/book_model.php';
+$search = isset($_GET['search']) ? $_GET['search'] : '';
+$order = isset($_GET['order']) ? $_GET['order'] : 'title';
 $books = get_books($search, $order, true);
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/books.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/books.php';
+include 'views/footer.php';

--- a/controllers/borrow_book.php
+++ b/controllers/borrow_book.php
@@ -1,11 +1,11 @@
 <?php
-require_once __DIR__ . '/../models/borrow_model.php';
-require_once __DIR__ . '/../models/book_model.php';
+include 'models/borrow_model.php';
+include 'models/book_model.php';
 if (!isset($_SESSION['user_id'])) {
     header('Location: index.php?page=login');
     exit;
 }
-$book_id = $_GET['id'] ?? 0;
+$book_id = isset($_GET['id']) ? $_GET['id'] : 0;
 $book = get_book($book_id);
 if (!$book) {
     header('Location: index.php?page=books');

--- a/controllers/borrowings.php
+++ b/controllers/borrowings.php
@@ -1,10 +1,10 @@
 <?php
-require_once __DIR__ . '/../models/borrow_model.php';
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+include 'models/borrow_model.php';
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] != 'admin') {
     header('Location: index.php?page=login');
     exit;
 }
 $records = get_all_borrowings();
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/borrowings.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/borrowings.php';
+include 'views/footer.php';

--- a/controllers/dashboard.php
+++ b/controllers/dashboard.php
@@ -1,17 +1,17 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
-require_once __DIR__ . '/../models/borrow_model.php';
+include 'models/book_model.php';
+include 'models/borrow_model.php';
 if (!isset($_SESSION['user_id'])) {
     header('Location: index.php?page=login');
     exit;
 }
-if ($_SESSION['role'] === 'admin') {
+if ($_SESSION['role'] == 'admin') {
     $books = get_books();
-    $borrowings = [];
+    $borrowings = array();
 } else {
-    $books = [];
+    $books = array();
     $borrowings = get_user_borrowings($_SESSION['user_id']);
 }
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/dashboard.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/dashboard.php';
+include 'views/footer.php';

--- a/controllers/delete_book.php
+++ b/controllers/delete_book.php
@@ -1,9 +1,9 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+include 'models/book_model.php';
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] != 'admin') {
     header('Location: index.php?page=login');
     exit;
 }
-$id = $_GET['id'] ?? 0;
+$id = isset($_GET['id']) ? $_GET['id'] : 0;
 delete_book($id);
 header('Location: index.php?page=dashboard');

--- a/controllers/edit_book.php
+++ b/controllers/edit_book.php
@@ -1,21 +1,21 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+include 'models/book_model.php';
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] != 'admin') {
     header('Location: index.php?page=login');
     exit;
 }
-$id = $_GET['id'] ?? 0;
+$id = isset($_GET['id']) ? $_GET['id'] : 0;
 $book = get_book($id);
 $message = '';
 if (!$book) {
     header('Location: index.php?page=dashboard');
     exit;
 }
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $title = $_POST['title'] ?? '';
-    $author = $_POST['author'] ?? '';
-    $category = $_POST['category'] ?? '';
-    $isbn = $_POST['isbn'] ?? '';
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $title = isset($_POST['title']) ? $_POST['title'] : '';
+    $author = isset($_POST['author']) ? $_POST['author'] : '';
+    $category = isset($_POST['category']) ? $_POST['category'] : '';
+    $isbn = isset($_POST['isbn']) ? $_POST['isbn'] : '';
     if (update_book($id, $title, $author, $category, $isbn)) {
         header('Location: index.php?page=dashboard');
         exit;
@@ -23,6 +23,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $message = 'Failed to update book';
     }
 }
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/edit_book.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/edit_book.php';
+include 'views/footer.php';

--- a/controllers/home.php
+++ b/controllers/home.php
@@ -1,6 +1,6 @@
 <?php
-require_once __DIR__ . '/../models/book_model.php';
+include 'models/book_model.php';
 $books = get_books('', 'title', true);
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/home.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/home.php';
+include 'views/footer.php';

--- a/controllers/login.php
+++ b/controllers/login.php
@@ -1,9 +1,9 @@
 <?php
-require_once __DIR__ . '/../models/user_model.php';
+include 'models/user_model.php';
 $message = '';
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
-    $password = $_POST['password'] ?? '';
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $email = isset($_POST['email']) ? $_POST['email'] : '';
+    $password = isset($_POST['password']) ? $_POST['password'] : '';
     $user = find_user_by_email($email);
     if ($user && password_verify($password, $user['password'])) {
         $_SESSION['user_id'] = $user['id'];
@@ -14,6 +14,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $message = 'Invalid credentials';
     }
 }
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/login.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/login.php';
+include 'views/footer.php';

--- a/controllers/register.php
+++ b/controllers/register.php
@@ -1,9 +1,9 @@
 <?php
-require_once __DIR__ . '/../models/user_model.php';
+include 'models/user_model.php';
 $message = '';
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
-    $password = $_POST['password'] ?? '';
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $email = isset($_POST['email']) ? $_POST['email'] : '';
+    $password = isset($_POST['password']) ? $_POST['password'] : '';
     if (find_user_by_email($email)) {
         $message = 'User already exists';
     } else {
@@ -15,6 +15,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
-include __DIR__ . '/../views/header.php';
-include __DIR__ . '/../views/register.php';
-include __DIR__ . '/../views/footer.php';
+include 'views/header.php';
+include 'views/register.php';
+include 'views/footer.php';

--- a/controllers/return_book.php
+++ b/controllers/return_book.php
@@ -1,9 +1,9 @@
 <?php
-require_once __DIR__ . '/../models/borrow_model.php';
+include 'models/borrow_model.php';
 if (!isset($_SESSION['user_id'])) {
     header('Location: index.php?page=login');
     exit;
 }
-$borrow_id = $_GET['id'] ?? 0;
+$borrow_id = isset($_GET['id']) ? $_GET['id'] : 0;
 return_book($borrow_id);
 header('Location: index.php?page=dashboard');

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-require 'models/db.php';
+require_once 'models/db.php';
 
 $page = isset($_GET['page']) ? $_GET['page'] : 'home';
 

--- a/index.php
+++ b/index.php
@@ -1,46 +1,46 @@
 <?php
 session_start();
-require_once __DIR__ . '/models/db.php';
+require 'models/db.php';
 
 $page = isset($_GET['page']) ? $_GET['page'] : 'home';
 
 switch ($page) {
     case 'login':
-        require __DIR__ . '/controllers/login.php';
+        require 'controllers/login.php';
         break;
     case 'register':
-        require __DIR__ . '/controllers/register.php';
+        require 'controllers/register.php';
         break;
     case 'books':
-        require __DIR__ . '/controllers/books.php';
+        require 'controllers/books.php';
         break;
     case 'book':
-        require __DIR__ . '/controllers/book.php';
+        require 'controllers/book.php';
         break;
     case 'add_book':
-        require __DIR__ . '/controllers/add_book.php';
+        require 'controllers/add_book.php';
         break;
     case 'edit_book':
-        require __DIR__ . '/controllers/edit_book.php';
+        require 'controllers/edit_book.php';
         break;
     case 'delete_book':
-        require __DIR__ . '/controllers/delete_book.php';
+        require 'controllers/delete_book.php';
         break;
     case 'borrow_book':
-        require __DIR__ . '/controllers/borrow_book.php';
+        require 'controllers/borrow_book.php';
         break;
     case 'return_book':
-        require __DIR__ . '/controllers/return_book.php';
+        require 'controllers/return_book.php';
         break;
     case 'borrowings':
-        require __DIR__ . '/controllers/borrowings.php';
+        require 'controllers/borrowings.php';
         break;
     case 'logout':
-        require __DIR__ . '/controllers/logout.php';
+        require 'controllers/logout.php';
         break;
     case 'dashboard':
-        require __DIR__ . '/controllers/dashboard.php';
+        require 'controllers/dashboard.php';
         break;
     default:
-        require __DIR__ . '/controllers/home.php';
+        require 'controllers/home.php';
 }

--- a/models/book_model.php
+++ b/models/book_model.php
@@ -1,27 +1,25 @@
 <?php
-require_once __DIR__ . '/db.php';
+include 'models/db.php';
 
 function get_books($search = '', $order = 'title', $available_only = false) {
     $db = get_db();
-    $sql = 'SELECT b.* FROM books b';
-    $params = [];
+    $sql = "SELECT b.* FROM books b";
     if ($available_only) {
-        $sql .= ' LEFT JOIN borrowings br ON b.id = br.book_id AND br.return_date IS NULL';
+        $sql .= " LEFT JOIN borrowings br ON b.id = br.book_id AND br.return_date IS NULL";
     }
-    $conditions = [];
+    $sql .= " WHERE 1=1";
+    $params = array();
     if ($available_only) {
-        $conditions[] = 'br.id IS NULL';
+        $sql .= " AND br.id IS NULL";
     }
-    if ($search !== '') {
-        $conditions[] = '(b.title LIKE ? OR b.author LIKE ? OR b.category LIKE ?)';
+    if ($search != '') {
+        $sql .= " AND (b.title LIKE ? OR b.author LIKE ? OR b.category LIKE ?)";
         $wild = '%' . $search . '%';
-        $params = array_merge($params, [$wild, $wild, $wild]);
+        $params[] = $wild;
+        $params[] = $wild;
+        $params[] = $wild;
     }
-    if ($conditions) {
-        $sql .= ' WHERE ' . implode(' AND ', $conditions);
-    }
-    $allowed = ['title', 'author', 'category'];
-    if (!in_array($order, $allowed)) {
+    if ($order != 'author' && $order != 'category') {
         $order = 'title';
     }
     $sql .= " ORDER BY b.$order";
@@ -33,24 +31,24 @@ function get_books($search = '', $order = 'title', $available_only = false) {
 function get_book($id) {
     $db = get_db();
     $stmt = $db->prepare('SELECT * FROM books WHERE id = ?');
-    $stmt->execute([$id]);
+    $stmt->execute(array($id));
     return $stmt->fetch(PDO::FETCH_ASSOC);
 }
 
 function add_book($title, $author, $category, $isbn) {
     $db = get_db();
     $stmt = $db->prepare('INSERT INTO books (title, author, category, isbn) VALUES (?, ?, ?, ?)');
-    return $stmt->execute([$title, $author, $category, $isbn]);
+    return $stmt->execute(array($title, $author, $category, $isbn));
 }
 
 function update_book($id, $title, $author, $category, $isbn) {
     $db = get_db();
     $stmt = $db->prepare('UPDATE books SET title = ?, author = ?, category = ?, isbn = ? WHERE id = ?');
-    return $stmt->execute([$title, $author, $category, $isbn, $id]);
+    return $stmt->execute(array($title, $author, $category, $isbn, $id));
 }
 
 function delete_book($id) {
     $db = get_db();
     $stmt = $db->prepare('DELETE FROM books WHERE id = ?');
-    return $stmt->execute([$id]);
+    return $stmt->execute(array($id));
 }

--- a/models/book_model.php
+++ b/models/book_model.php
@@ -1,5 +1,5 @@
 <?php
-include 'models/db.php';
+require_once __DIR__ . '/db.php';
 
 function get_books($search = '', $order = 'title', $available_only = false) {
     $db = get_db();

--- a/models/borrow_model.php
+++ b/models/borrow_model.php
@@ -1,10 +1,10 @@
 <?php
-require_once __DIR__ . '/db.php';
+include 'models/db.php';
 
 function is_book_borrowed($book_id) {
     $db = get_db();
     $stmt = $db->prepare('SELECT COUNT(*) FROM borrowings WHERE book_id = ? AND return_date IS NULL');
-    $stmt->execute([$book_id]);
+    $stmt->execute(array($book_id));
     return $stmt->fetchColumn() > 0;
 }
 
@@ -14,13 +14,13 @@ function borrow_book($book_id, $user_id) {
     }
     $db = get_db();
     $stmt = $db->prepare('INSERT INTO borrowings (user_id, book_id) VALUES (?, ?)');
-    return $stmt->execute([$user_id, $book_id]);
+    return $stmt->execute(array($user_id, $book_id));
 }
 
 function return_book($borrow_id) {
     $db = get_db();
     $stmt = $db->prepare('UPDATE borrowings SET return_date = NOW() WHERE id = ?');
-    return $stmt->execute([$borrow_id]);
+    return $stmt->execute(array($borrow_id));
 }
 
 function get_user_borrowings($user_id) {
@@ -28,14 +28,14 @@ function get_user_borrowings($user_id) {
     $stmt = $db->prepare('SELECT br.id as borrow_id, b.* , br.borrow_date, br.return_date
                           FROM borrowings br JOIN books b ON br.book_id = b.id
                           WHERE br.user_id = ? AND br.return_date IS NULL');
-    $stmt->execute([$user_id]);
+    $stmt->execute(array($user_id));
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
 function get_user_active_borrow($user_id, $book_id) {
     $db = get_db();
     $stmt = $db->prepare('SELECT id FROM borrowings WHERE user_id = ? AND book_id = ? AND return_date IS NULL');
-    $stmt->execute([$user_id, $book_id]);
+    $stmt->execute(array($user_id, $book_id));
     return $stmt->fetch(PDO::FETCH_ASSOC);
 }
 

--- a/models/borrow_model.php
+++ b/models/borrow_model.php
@@ -1,5 +1,5 @@
 <?php
-include 'models/db.php';
+require_once __DIR__ . '/db.php';
 
 function is_book_borrowed($book_id) {
     $db = get_db();

--- a/models/db.php
+++ b/models/db.php
@@ -2,19 +2,15 @@
 // Database connection using PDO
 
 function get_db() {
-    static $db = null;
-    if ($db === null) {
-        $host = 'localhost';
-        $dbname = 'electronic_library';
-        $user = 'ts_user';
-        $pass = 'pa55word';
-        $dsn = "mysql:host=$host;dbname=$dbname;charset=utf8mb4";
-        try {
-            $db = new PDO($dsn, $user, $pass);
-            $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        } catch (PDOException $e) {
-            die('Connection failed: ' . $e->getMessage());
-        }
+    $host = 'localhost';
+    $dbname = 'electronic_library';
+    $user = 'ts_user';
+    $pass = 'pa55word';
+    try {
+        $db = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8mb4", $user, $pass);
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    } catch (PDOException $e) {
+        die('Connection failed: ' . $e->getMessage());
     }
     return $db;
 }

--- a/models/user_model.php
+++ b/models/user_model.php
@@ -1,5 +1,5 @@
 <?php
-include 'models/db.php';
+require_once __DIR__ . '/db.php';
 
 function find_user_by_email($email) {
     $db = get_db();

--- a/models/user_model.php
+++ b/models/user_model.php
@@ -1,10 +1,10 @@
 <?php
-require_once __DIR__ . '/db.php';
+include 'models/db.php';
 
 function find_user_by_email($email) {
     $db = get_db();
     $stmt = $db->prepare('SELECT * FROM users WHERE email = ?');
-    $stmt->execute([$email]);
+    $stmt->execute(array($email));
     return $stmt->fetch(PDO::FETCH_ASSOC);
 }
 
@@ -12,5 +12,5 @@ function create_user($email, $password, $role = 'user') {
     $db = get_db();
     $hash = password_hash($password, PASSWORD_DEFAULT);
     $stmt = $db->prepare('INSERT INTO users (email, password, role) VALUES (?, ?, ?)');
-    return $stmt->execute([$email, $hash, $role]);
+    return $stmt->execute(array($email, $hash, $role));
 }

--- a/views/book.php
+++ b/views/book.php
@@ -1,10 +1,14 @@
-<?php if ($book): ?>
+<?php
+if ($book) {
+?>
 <h1><?php echo htmlspecialchars($book['title']); ?></h1>
 <p>Author: <?php echo htmlspecialchars($book['author']); ?></p>
 <p>Category: <?php echo htmlspecialchars($book['category']); ?></p>
 <p>ISBN: <?php echo htmlspecialchars($book['isbn']); ?></p>
-<?php if (isset($_SESSION['user_id'])): ?>
-    <?php if ($_SESSION['role'] === 'admin'): ?>
+<?php
+    if (isset($_SESSION['user_id'])) {
+        if ($_SESSION['role'] == 'admin') {
+?>
         <form method="get" action="index.php" style="display:inline">
             <input type="hidden" name="page" value="edit_book">
             <input type="hidden" name="id" value="<?php echo $book['id']; ?>">
@@ -15,24 +19,34 @@
             <input type="hidden" name="id" value="<?php echo $book['id']; ?>">
             <button type="submit">Delete</button>
         </form>
-    <?php else: ?>
-        <?php if ($user_borrow_id): ?>
+<?php
+        } else {
+            if ($user_borrow_id) {
+?>
             <form method="get" action="index.php">
                 <input type="hidden" name="page" value="return_book">
                 <input type="hidden" name="id" value="<?php echo $user_borrow_id; ?>">
                 <button type="submit">Return Book</button>
             </form>
-        <?php elseif (!$is_borrowed): ?>
+<?php
+            } elseif (!$is_borrowed) {
+?>
             <form method="get" action="index.php">
                 <input type="hidden" name="page" value="borrow_book">
                 <input type="hidden" name="id" value="<?php echo $book['id']; ?>">
                 <button type="submit">Borrow Book</button>
             </form>
-        <?php else: ?>
+<?php
+            } else {
+?>
             <p>This book is currently borrowed.</p>
-        <?php endif; ?>
-    <?php endif; ?>
-<?php endif; ?>
-<?php else: ?>
+<?php
+            }
+        }
+    }
+} else {
+?>
 <p>Book not found.</p>
-<?php endif; ?>
+<?php
+}
+?>

--- a/views/books.php
+++ b/views/books.php
@@ -11,7 +11,7 @@
 </form>
 <table>
     <tr><th>Title</th><th>Author</th><th>Category</th></tr>
-    <?php foreach ($books as $b): ?>
+    <?php foreach ($books as $b) { ?>
     <tr>
         <td>
             <form method="get" action="index.php" style="display:inline">
@@ -23,5 +23,5 @@
         <td><?php echo htmlspecialchars($b['author']); ?></td>
         <td><?php echo htmlspecialchars($b['category']); ?></td>
     </tr>
-    <?php endforeach; ?>
+    <?php } ?>
 </table>

--- a/views/borrowings.php
+++ b/views/borrowings.php
@@ -1,12 +1,12 @@
 <h1>Borrowing Records</h1>
 <table>
     <tr><th>Book</th><th>User</th><th>Borrowed</th><th>Returned</th></tr>
-    <?php foreach ($records as $r): ?>
+    <?php foreach ($records as $r) { ?>
     <tr>
         <td><?php echo htmlspecialchars($r['title']); ?></td>
         <td><?php echo htmlspecialchars($r['email']); ?></td>
         <td><?php echo htmlspecialchars($r['borrow_date']); ?></td>
         <td><?php echo $r['return_date'] ? htmlspecialchars($r['return_date']) : 'Not returned'; ?></td>
     </tr>
-    <?php endforeach; ?>
+    <?php } ?>
 </table>

--- a/views/dashboard.php
+++ b/views/dashboard.php
@@ -1,19 +1,19 @@
-<?php if ($_SESSION['role'] === 'admin'): ?>
+<?php if ($_SESSION['role'] == 'admin') { ?>
 <h1>All Books</h1>
-<?php else: ?>
+<?php } else { ?>
 <h1>Borrowed Books</h1>
-<?php endif; ?>
+<?php } ?>
 
 <p>Welcome, <?php echo htmlspecialchars($_SESSION['role']); ?>.</p>
 
-<?php if ($_SESSION['role'] === 'admin'): ?>
+<?php if ($_SESSION['role'] == 'admin') { ?>
     <form method="get" action="index.php">
         <input type="hidden" name="page" value="add_book">
         <button type="submit">Add Book</button>
     </form>
     <table>
         <tr><th>Title</th><th>Actions</th></tr>
-        <?php foreach ($books as $b): ?>
+        <?php foreach ($books as $b) { ?>
         <tr>
             <td><?php echo htmlspecialchars($b['title']); ?></td>
             <td>
@@ -29,13 +29,13 @@
                 </form>
             </td>
         </tr>
-        <?php endforeach; ?>
+        <?php } ?>
     </table>
-<?php else: ?>
+<?php } else { ?>
     <h2>Your Borrowed Books</h2>
     <table>
         <tr><th>Title</th><th>Author</th><th>Return</th></tr>
-        <?php foreach ($borrowings as $b): ?>
+        <?php foreach ($borrowings as $b) { ?>
         <tr>
             <td><?php echo htmlspecialchars($b['title']); ?></td>
             <td><?php echo htmlspecialchars($b['author']); ?></td>
@@ -47,6 +47,6 @@
                 </form>
             </td>
         </tr>
-        <?php endforeach; ?>
+        <?php } ?>
     </table>
-<?php endif; ?>
+<?php } ?>

--- a/views/header.php
+++ b/views/header.php
@@ -9,19 +9,19 @@
 <nav>
     <a href="index.php">Home</a>
     <a href="index.php?page=books">Available Books</a>
-    <?php if (isset($_SESSION['user_id'])): ?>
-        <?php if ($_SESSION['role'] === 'admin'): ?>
+    <?php if (isset($_SESSION['user_id'])) { ?>
+        <?php if ($_SESSION['role'] == 'admin') { ?>
         <a href="index.php?page=dashboard">All Books</a>
-        <?php else: ?>
+        <?php } else { ?>
         <a href="index.php?page=dashboard">Borrowed Books</a>
-        <?php endif; ?>
-        <?php if ($_SESSION['role'] === 'admin'): ?>
+        <?php } ?>
+        <?php if ($_SESSION['role'] == 'admin') { ?>
             <a href="index.php?page=borrowings">Borrowings</a>
-        <?php endif; ?>
+        <?php } ?>
         <a href="index.php?page=logout">Logout</a>
-    <?php else: ?>
+    <?php } else { ?>
         <a href="index.php?page=login">Login</a>
         <a href="index.php?page=register">Register</a>
-    <?php endif; ?>
+    <?php } ?>
 </nav>
 <div class="container">

--- a/views/home.php
+++ b/views/home.php
@@ -1,7 +1,7 @@
 <h1>Welcome to the E-Library</h1>
 <p>Browse our collection of available books.</p>
 <ul>
-<?php foreach ($books as $b): ?>
+<?php foreach ($books as $b) { ?>
     <li>
         <form method="get" action="index.php" style="display:inline">
             <input type="hidden" name="page" value="book">
@@ -10,5 +10,5 @@
         </form>
         by <?php echo htmlspecialchars($b['author']); ?>
     </li>
-<?php endforeach; ?>
+<?php } ?>
 </ul>


### PR DESCRIPTION
## Summary
- Simplify index routing with basic `require` calls
- Use straightforward database helpers and controllers with explicit `isset` checks
- Replace PHP template shortcuts with basic loops and conditionals

## Testing
- `php -l index.php controllers/*.php models/*.php views/*.php`

------
https://chatgpt.com/codex/tasks/task_e_689df7746ebc832cb8c685ad9be598a5